### PR TITLE
Fix build error in gcc compiler.

### DIFF
--- a/excuter/cpp-common/src/deepx/dtype.hpp
+++ b/excuter/cpp-common/src/deepx/dtype.hpp
@@ -2,6 +2,8 @@
 #define DEEPX_DTYPE_HPP
 
 #include <string>
+#include <cstdint>
+
 namespace deepx
 {
 


### PR DESCRIPTION
In gcc/++13 compiler, it shows error:
```
dtype.hpp:8:29: error: found ‘:’ in nested-name-specifier, expected ‘::’
8 | enum class DataCategory : uint8_t
```